### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/www/assets/js/form.ts
+++ b/www/assets/js/form.ts
@@ -68,7 +68,12 @@ async function createOrUpdate(): Promise<void> {
     if (redirectInput) {
       const redirectUrl = redirectInput.value;
       if (redirectUrl) {
-        window.location.href = redirectUrl;
+        try {
+          const url = new URL(redirectUrl);
+          window.location.href = url.href;
+        } catch (e) {
+          console.error("Invalid URL:", redirectUrl);
+        }
       }
     }
   } finally {


### PR DESCRIPTION
Fixes [https://github.com/jmservera/cecinestpasunmariage/security/code-scanning/1](https://github.com/jmservera/cecinestpasunmariage/security/code-scanning/1)

To fix the problem, we need to ensure that the `redirectUrl` is properly sanitized or validated before it is used to set `window.location.href`. One effective way to do this is to use a URL parsing library to validate the URL and ensure it is safe.

- We will use the `URL` constructor to parse and validate the `redirectUrl`.
- If the `redirectUrl` is not a valid URL, we will not perform the redirection.
- This change will be made in the `createOrUpdate` function, specifically around lines 69-71.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
