### PR TITLE
Fix code scanning alert no. 3: Exposure of private information

### DIFF
--- a/backend/functions/Audit/AuditCosmosServiceOfT.cs
+++ b/backend/functions/Audit/AuditCosmosServiceOfT.cs
@@ -18,8 +18,8 @@ public class AuditInCosmosService<T>(IAuditServiceFactory auditServiceFactory) :
     /// <param name="user">The user who performed the operation.</param>
     /// <param name="operation">The operation that was performed.</param>
     /// <param name="result">The result of the operation.</param>
-    public void Audit(string user, string operation, string result)
+    public void Audit(string user, string operation, string result, string? operationId = null)
     {
-        _auditService.Audit(user, operation, result);
+        _auditService.Audit(user, operation, result, operationId);
     }
 }

--- a/backend/functions/Audit/IAuditService.cs
+++ b/backend/functions/Audit/IAuditService.cs
@@ -11,7 +11,7 @@ public interface IAuditService
     /// <param name="user"> The user who performed the operation. </param>
     /// <param name="operation"> The operation that was performed. </param>
     /// <param name="result"> The result of the operation. </param>
-    public void Audit(string user, string operation, string result);
+    public void Audit(string user, string operation, string result, string? operationId = null);
 
     /// <summary>
     /// Initializes the audit service.

--- a/backend/functions/Audit/IAuditServiceOfT.cs
+++ b/backend/functions/Audit/IAuditServiceOfT.cs
@@ -12,5 +12,5 @@ public interface IAuditService<out T>
     /// <param name="user"> The user who performed the operation. </param>
     /// <param name="operation"> The operation that was performed. </param>
     /// <param name="result"> The result of the operation. </param>
-    public void Audit(string user, string operation, string result);
+    public void Audit(string user, string operation, string result, string? operationId = null);
 }

--- a/backend/functions/CosmosChanges.cs
+++ b/backend/functions/CosmosChanges.cs
@@ -49,13 +49,15 @@ public class CosmosChanges(ILogger<CosmosChanges> logger, IEmailMessaging emailM
 
                 message += "\nThank you for registering!\n We look forward to having lots of fun together.\n You can review your changes at <a href=\"https://cecinestpasunmariage.org/registro/\">cecinestpasunmariage.org</a>";
 
-                var adminResult = await emailMessaging.SendEmailAsync(logAdmin, "Important user update at cecinestpasunmariage.org", adminMessage);
-                auditService.Audit("system", "update sent to admin", adminResult);
+                var operationId = Guid.NewGuid().ToString();
+                var adminResult = await emailMessaging.SendEmailAsync(logAdmin, "Important user update at cecinestpasunmariage.org", adminMessage, operationId);
+                auditService.Audit("system", $"update sent to admin {logAdmin}", adminResult, operationId);
 
                 if (!string.IsNullOrEmpty(email))
                 {
-                    var userResult = await emailMessaging.SendEmailAsync(email, $"Important update, you {operation} your user at cecinestpasunmariage.org", message);
-                    auditService.Audit("system", "update sent to user", userResult);
+                    var userOperationId = Guid.NewGuid().ToString();
+                    var userResult = await emailMessaging.SendEmailAsync(email, $"Important update, you {operation} your user at cecinestpasunmariage.org", message, userOperationId);
+                    auditService.Audit("system", $"{operation} sent to user {email}", userResult, userOperationId);
                 }
             }
         }

--- a/backend/functions/Messaging/Email.cs
+++ b/backend/functions/Messaging/Email.cs
@@ -23,15 +23,26 @@ public class EmailMessagingACS(IConfiguration configuration, ILogger<EmailMessag
         },
         recipients: new EmailRecipients([new EmailAddress(to)]));
         var emailSendOperation = await emailClient.SendAsync(WaitUntil.Completed, emailMessage);
+        string maskedEmail = MaskEmail(to);
         if (emailSendOperation.Value.Status == EmailSendStatus.Failed)
         {
-            logger.LogError("Failed to send email to {to} with subject {subject} and result {result}", to, subject, emailSendOperation.Value);
+            logger.LogError("Failed to send email to {maskedEmail} with subject {subject} and result {result}", maskedEmail, subject, emailSendOperation.Value);
         }
         else
         {
-            logger.LogInformation("Email sent to {to} with subject {subject} and result {result}", to, subject, emailSendOperation.Value.Status);
+            logger.LogInformation("Email sent to {maskedEmail} with subject {subject} and result {result}", maskedEmail, subject, emailSendOperation.Value.Status);
         }
 
         return emailSendOperation.Value.Status.ToString();
+    }
+
+    private string MaskEmail(string email)
+    {
+        var atIndex = email.IndexOf('@');
+        if (atIndex <= 1)
+        {
+            return email; // Not enough characters to mask
+        }
+        return email.Substring(0, 1) + "****" + email.Substring(atIndex - 1);
     }
 }

--- a/backend/functions/Messaging/Email.cs
+++ b/backend/functions/Messaging/Email.cs
@@ -2,13 +2,12 @@ using Azure;
 using Azure.Communication.Email;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using System.Security.Cryptography;
 
 namespace functions.Messaging;
 
 public class EmailMessagingACS(IConfiguration configuration, ILogger<EmailMessagingACS> logger) : IEmailMessaging
 {
-    public async Task<string> SendEmailAsync(string to, string subject, string body)
+    public async Task<string> SendEmailAsync(string to, string subject, string body, string operationId)
     {
         string connectionString = configuration.GetValue<string>("COMMUNICATION_SERVICES_CONNECTION_STRING") ?? throw new InvalidOperationException("COMMUNICATION_SERVICES_CONNECTION_STRING is not set.");
         string sender = configuration.GetValue<string>("COMMUNICATION_SERVICES_SENDER") ?? throw new InvalidOperationException("COMMUNICATION_SERVICES_SENDER is not set.");
@@ -24,25 +23,15 @@ public class EmailMessagingACS(IConfiguration configuration, ILogger<EmailMessag
         },
         recipients: new EmailRecipients([new EmailAddress(to)]));
         var emailSendOperation = await emailClient.SendAsync(WaitUntil.Completed, emailMessage);
-        string hashedEmail = HashEmail(to);
         if (emailSendOperation.Value.Status == EmailSendStatus.Failed)
         {
-            logger.LogError("Failed to send email to {hashedEmail} with subject {subject} and result {result}", hashedEmail, subject, emailSendOperation.Value);
+            logger.LogError("Failed to send email to {uid} with subject {subject} and result {result}", operationId, subject, emailSendOperation.Value);
         }
         else
         {
-            logger.LogInformation("Email sent to {hashedEmail} with subject {subject} and result {result}", hashedEmail, subject, emailSendOperation.Value.Status);
+            logger.LogInformation("Email sent to {uid} with subject {subject} and result {result}", operationId, subject, emailSendOperation.Value.Status);
         }
 
         return emailSendOperation.Value.Status.ToString();
-    }
-
-    private string HashEmail(string email)
-    {
-        using (var sha256 = System.Security.Cryptography.SHA256.Create())
-        {
-            var hashedBytes = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(email));
-            return BitConverter.ToString(hashedBytes).Replace("-", "").ToLower();
-        }
     }
 }

--- a/backend/functions/Messaging/IEmailMessaging.cs
+++ b/backend/functions/Messaging/IEmailMessaging.cs
@@ -2,5 +2,5 @@ namespace functions.Messaging;
 
 public interface IEmailMessaging
 {
-    Task<string> SendEmailAsync(string to, string subject, string body);
+    Task<string> SendEmailAsync(string to, string subject, string body, string operationId);
 }

--- a/backend/functions/SendEmail.cs
+++ b/backend/functions/SendEmail.cs
@@ -1,19 +1,10 @@
-using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text.Json;
-using Azure;
-using Azure.AI.OpenAI;
-using Azure.Communication.Email;
 using functions.Audit;
 using functions.Claims;
 using functions.Messaging;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace functions
@@ -40,12 +31,13 @@ namespace functions
 
             foreach (var recipient in data.recipients)
             {
-                var emailSendOperation = await emailMessaging.SendEmailAsync(recipient, data.title, data.message);
+                var operationId = Guid.NewGuid().ToString();
+                var emailSendOperation = await emailMessaging.SendEmailAsync(recipient, data.title, data.message, operationId);
                 if (emailSendOperation != "Succeeded")
                 {
                     response += $"Failed to send email to {recipient}: {emailSendOperation}." + Environment.NewLine;
                 }
-                auditService.Audit(principal.Identity?.Name ?? "system", "email", $"Sent email to {recipient} with result {emailSendOperation}");
+                auditService.Audit(principal.Identity?.Name ?? "system", "email", $"Sent email to {recipient} with result {emailSendOperation}", operationId);
             }
 
             if (!string.IsNullOrEmpty(response))


### PR DESCRIPTION
Fixes [https://github.com/jmservera/cecinestpasunmariage/security/code-scanning/3](https://github.com/jmservera/cecinestpasunmariage/security/code-scanning/3)

To fix the problem, we should avoid logging the email address directly. Instead, we can log a masked version of the email address or use a unique identifier that does not expose private information. This approach ensures that the logs remain useful for debugging purposes without compromising user privacy.

- Modify the logging statements to mask the email address.
- Ensure that the changes are made in the `SendEmailAsync` method in the `EmailMessagingACS` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
