### PR TITLE
Add ChatUserCipher for encrypting and validating chat user data

### DIFF
--- a/backend/functions.Test/ChatUserCipherTest.cs
+++ b/backend/functions.Test/ChatUserCipherTest.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Text;
+using Xunit;
+using functions.Identity;
+
+namespace functions.Test
+{
+    public class ChatUserCipherTest
+    {
+        private const string chatId = "chat123";
+        private const string userName = "user123";
+
+        private const string EncryptionKey = "your-encryption-key-1234"; // Ensure this key is 16, 24, or 32 bytes long
+        private const string fakeButCompliantIV = "uHYiCunR+dyJoBO9mSINsA==";
+        private const string unrelatedEncryptedUser = "jEfVXe5cXdk8Hz7RPHh8kqAIlyo2x6a6UZxFaBYrbGz2cyQ=";
+
+        private const string oldEncryptedUser = "Kv5iitlqbKi/3jtlfBwxuot8qw7ifdmI1/upvXuSxZAjg0Y=";
+        private const string oldIV = "Z2YdNXA4qUWSH7kOWLDALA==";
+
+        [Fact]
+        public void Encrypt_ShouldEncryptUser()
+        {
+            var user = new ChatUser
+            {
+                ChatId = chatId,
+                UserId = userName
+            };
+
+            var encryptedUser = ChatUser.TimeSeal(user, EncryptionKey);
+
+            Assert.NotNull(encryptedUser.Hash);
+            Assert.NotNull(encryptedUser.IV);
+            Assert.NotEqual(user.ChatId, encryptedUser.Hash);
+            Assert.NotEqual(user.UserId, encryptedUser.Hash);
+            Assert.NotEqual(user.IV, encryptedUser.IV);
+            Assert.NotEqual(user.Hash, encryptedUser.Hash);
+        }
+
+        [Fact]
+        public void CheckValidity_ShouldThrowExceptionForInvalidDate()
+        {
+            var user = new ChatUser
+            {
+                ChatId = chatId,
+                UserId = userName,
+                Hash = unrelatedEncryptedUser,
+                IV = fakeButCompliantIV
+            };
+
+            Assert.Throws<InvalidOperationException>(() => user.CheckSealValidity(EncryptionKey));
+        }
+
+        [Fact]
+        public void CheckValidity_ShouldThrowExceptionForExpiredDate()
+        {
+            // Valid User but old date
+            var encryptedUser = new ChatUser
+            {
+                ChatId = chatId,
+                UserId = userName,
+                Hash = oldEncryptedUser,
+                IV = oldIV
+            };
+
+            Assert.Throws<InvalidOperationException>(() => encryptedUser.CheckSealValidity(EncryptionKey, -1));
+        }
+
+        [Fact]
+        public void CheckValidity_ShouldPassForValidUser()
+        {
+            var user = new ChatUser
+            {
+                ChatId = chatId,
+                UserId = userName
+            };
+
+            var encryptedUser = ChatUser.TimeSeal(user, EncryptionKey);
+
+            Exception ex = Record.Exception(() => encryptedUser.CheckSealValidity(EncryptionKey));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/backend/functions/BotEndpoint.cs
+++ b/backend/functions/BotEndpoint.cs
@@ -5,6 +5,7 @@ using functions.Identity;
 using functions.Messaging;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -12,7 +13,7 @@ using Telegram.Bot.Types.ReplyMarkups;
 
 namespace functions
 {
-    public class BotEndpoint(ILoggerFactory loggerFactory, TelegramBot bot, IStringLocalizer<TelegramBot> localizer, IChatUserMapper chatUserMapper)
+    public class BotEndpoint(ILoggerFactory loggerFactory, TelegramBot bot, IStringLocalizer<TelegramBot> localizer, IChatUserMapper chatUserMapper, IConfiguration configuration)
     {
         const string SetUpFunctionName = "Cecinestpasunbotreg";
         const string UpdateFunctionName = "Cecinestpasunbot";
@@ -91,6 +92,8 @@ namespace functions
                     response.WriteString("Empty request.");
                     return response;
                 }
+                var key = configuration.GetValue<string>("TELEGRAM_TOKEN") ?? throw new InvalidOperationException("TELEGRAM_TOKEN is not set.");
+                chatUser.CheckSealValidity(ChatUser.GetValidKey(key));
                 await chatUserMapper.SaveUserAsync(chatUser);
                 response = req.CreateResponse(HttpStatusCode.OK);
                 response.Headers.Add("Content-Type", "application/json; charset=utf-8");

--- a/backend/functions/Identity/ChatUser.cs
+++ b/backend/functions/Identity/ChatUser.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace functions.Identity;
+
+public struct ChatUser
+{
+    public readonly string id { get { return ChatId; } }
+    public string ChatId { get; set; }
+    public string UserId { get; set; }
+    public string Hash { get; set; }
+    public string IV { get; set; }
+    public string? Language { get; set; }
+
+    const PaddingMode padding = PaddingMode.PKCS7;
+    const CipherMode cipher = CipherMode.CFB;
+
+    public static ChatUser TimeSeal(ChatUser user, string key)
+    {
+        var date = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+        string userSTr = $"{user.ChatId}{user.UserId}{date}";
+        var algorithm = Aes.Create();
+        algorithm.GenerateIV();
+        algorithm.Key = Encoding.UTF8.GetBytes(key);
+        algorithm.Padding = padding;
+        algorithm.Mode = cipher;
+
+        var encryptor = algorithm.CreateEncryptor(algorithm.Key, algorithm.IV);
+        using var ms = new MemoryStream();
+        using var cs = new CryptoStream(ms, encryptor, CryptoStreamMode.Write);
+        using var sw = new StreamWriter(cs);
+        sw.Write(userSTr);
+        sw.Flush();
+        cs.FlushFinalBlock();
+        user.Hash = Convert.ToBase64String(ms.ToArray());
+        user.IV = Convert.ToBase64String(algorithm.IV);
+        return user;
+    }
+
+    public readonly void CheckSealValidity(string key, int minutes = -10)
+    {
+        var algorithm = Aes.Create();
+        algorithm.Key = Encoding.UTF8.GetBytes(key);
+        algorithm.IV = Convert.FromBase64String(IV);
+        algorithm.Padding = padding;
+        algorithm.Mode = cipher;
+
+        var decryptor = algorithm.CreateDecryptor(algorithm.Key, algorithm.IV);
+        using var ms = new MemoryStream(Convert.FromBase64String(Hash));
+        using var cs = new CryptoStream(ms, decryptor, CryptoStreamMode.Read);
+        using var sr = new StreamReader(cs);
+        var decrypted = sr.ReadToEnd();
+        var date = decrypted[(ChatId.Length + UserId.Length)..];
+
+        // parse a date in the format "yyyy-MM-ddTHH:mm:ssZ"
+        if (!DateTime.TryParse(date, out var parsedDate))
+        {
+            throw new InvalidOperationException("Invalid date format");
+        }
+
+        if (parsedDate < DateTime.UtcNow.AddMinutes(minutes))
+        {
+            throw new InvalidOperationException("Expired");
+        }
+    }
+
+    public static string GetValidKey(string key)
+    {
+        if (key.Length < 16)
+        {
+            throw new InvalidOperationException("Key is too short.");
+        }
+        if (key.Length < 32)
+        {
+            return key.PadRight(32, '0');
+        }
+        else
+        {
+            return key[..32];
+        }
+    }
+}

--- a/backend/functions/Identity/IUserMapper.cs
+++ b/backend/functions/Identity/IUserMapper.cs
@@ -1,3 +1,8 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Unicode;
+using Microsoft.Identity.Client;
+
 namespace functions.Identity;
 
 public interface IChatUserMapper
@@ -5,12 +10,4 @@ public interface IChatUserMapper
     Task<ChatUser?> GetUserAsync(string chatId);
     Task RemoveUserAsync(string chatId);
     Task SaveUserAsync(ChatUser user);
-}
-
-public struct ChatUser
-{
-    public readonly string id { get { return ChatId; } }
-    public string ChatId { get; set; }
-    public string UserId { get; set; }
-    public string? Language { get; set; }
 }

--- a/backend/functions/Identity/MapChatToUser.cs
+++ b/backend/functions/Identity/MapChatToUser.cs
@@ -13,9 +13,6 @@ public class MapChatToUser : IChatUserMapper
     private readonly CosmosClient _cosmosClient;
     private readonly Container _container;
     private readonly ILogger _logger;
-
-    private static bool _initialized = false;
-
     private readonly string _dbName;
 
     private const string _containerName = "ChatToUserMapping";

--- a/backend/functions/Messaging/TelegramHandler.cs
+++ b/backend/functions/Messaging/TelegramHandler.cs
@@ -55,6 +55,8 @@ namespace functions.Messaging
                     Language = language
                 };
 
+                var key = config.GetValue<string>("TELEGRAM_TOKEN") ?? throw new InvalidOperationException("TELEGRAM_TOKEN is not set.");
+                chatUser = ChatUser.TimeSeal(chatUser, ChatUser.GetValidKey(key));
                 var usr = JsonConvert.SerializeObject(chatUser);
                 // encode user as a base64string
                 var userEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(usr));


### PR DESCRIPTION
This pull request includes significant updates to the `ChatUser` encryption and validation mechanisms, as well as improvements to the `BotEndpoint` and related files. The most important changes include adding encryption and decryption methods for `ChatUser`, updating the `BotEndpoint` to use these methods, and adding comprehensive tests for these functionalities.

### Encryption and Validation for `ChatUser`:

* [`backend/functions/Identity/ChatUser.cs`](diffhunk://#diff-cdbe8ecc0fc9e8fd0ed277c83580f47cc3a035fd61f393b01e560b3a5234797bR1-R82): Introduced encryption (`TimeSeal`) and decryption (`CheckSealValidity`) methods for `ChatUser`, ensuring data security by using AES encryption. Also added a method to validate the encryption key length (`GetValidKey`).

### Updates to `BotEndpoint`:

* [`backend/functions/BotEndpoint.cs`](diffhunk://#diff-1e65e9413e7d981dc013cf44aff22a4962da6feac415a812a9a9078041966c46R8-R16): Modified the `BotEndpoint` constructor to include `IConfiguration` and updated the `Authenticate` method to validate the `ChatUser` using the encryption key from the configuration. [[1]](diffhunk://#diff-1e65e9413e7d981dc013cf44aff22a4962da6feac415a812a9a9078041966c46R8-R16) [[2]](diffhunk://#diff-1e65e9413e7d981dc013cf44aff22a4962da6feac415a812a9a9078041966c46R95-R96)

### Test Enhancements:

* [`backend/functions.Test/ChatUserCipherTest.cs`](diffhunk://#diff-825c12149d3d1e6ac29a5a2ad77315dee9aa060eee101b11785dc11410d65e78R1-R83): Added unit tests for `ChatUser` encryption and validation methods to ensure correct functionality and handle edge cases.

### Codebase Simplification:

* [`backend/functions/Identity/IUserMapper.cs`](diffhunk://#diff-b722f35fda8e03cd50cabb2167090a66adc4dba62a31c527cd73325d839af16aL9-L16): Removed the `ChatUser` struct definition from this file as it was moved to a separate file.
* [`backend/functions/Identity/MapChatToUser.cs`](diffhunk://#diff-582d9aa212bdb66d09b65a232153a467806c900c6c2001cb5c2d2ce6880bce69L16-L18): Cleaned up unused code to simplify the `MapChatToUser` class.

### Additional Updates:

* [`backend/functions/Messaging/TelegramHandler.cs`](diffhunk://#diff-a732999c8274c720f498100b7e8f480547f27a3c8fbf49f43197213239505fd8R58-R59): Incorporated the `TimeSeal` method to encrypt `ChatUser` before saving.